### PR TITLE
ec/include/README fix

### DIFF
--- a/ec/include/README.md
+++ b/ec/include/README.md
@@ -1,13 +1,11 @@
-
 This directory is intended for project header files.
 
-A header file is a file containing C declarations and macro definitions
+A header file contains C declarations and macro definitions
 to be shared between several project source files. You request the use of a
 header file in your project source file (C, C++, etc) located in `src` folder
 by including it, with the C preprocessing directive `#include'.
 
 ```src/main.c
-
 #include "header.h"
 
 int main (void)


### PR DESCRIPTION
- The file name missed the .md which ﻿caused it to not be rendered as intended on GitHub.
- Fixed the word redundancy in one of the sentences.
