### PR TITLE
fix: README file name fix + content fix for code block

### DIFF
--- a/ec/lib/README.md
+++ b/ec/lib/README.md
@@ -1,4 +1,3 @@
-
 This directory is intended for project specific (private) libraries.
 PlatformIO will compile them to static libraries and link into executable file.
 
@@ -6,7 +5,7 @@ The source code of each library should be placed in an own separate directory
 ("lib/your_library_name/[here are source files]").
 
 For example, see a structure of the following two libraries `Foo` and `Bar`:
-
+```
 |--lib
 |  |
 |  |--Bar
@@ -26,9 +25,10 @@ For example, see a structure of the following two libraries `Foo` and `Bar`:
 |- platformio.ini
 |--src
    |- main.c
+```
 
 and a contents of `src/main.c`:
-```
+```c
 #include <Foo.h>
 #include <Bar.h>
 
@@ -36,7 +36,6 @@ int main (void)
 {
   ...
 }
-
 ```
 
 PlatformIO Library Dependency Finder will find automatically dependent


### PR DESCRIPTION
- Fixed file by added .md to render as intended on GitHub.
- Added missing properties of the multi line code blocks.