### PR TITLE
bug fix: thermal degree detection typo creates unrechable if-statement

### DIFF
--- a/ec/src/main.cpp
+++ b/ec/src/main.cpp
@@ -265,7 +265,7 @@ void loop()
         batteryPercent = (LTC2943_code_to_mAh(charge, 0.01, 4096) * 100 / (float)4250);
         Serial.println(batteryPercent);
 
-        if ((LTC2943_code_to_celcius_temperature(temperature), 4) >= 60)
+        if (LTC2943_code_to_celcius_temperature(temperature) >= 60)
         {
             // thermal shutdown
             writeRegister16(CHARGECURRENT_LSB, 0x0000);


### PR DESCRIPTION
I'm not sure if this was added intentionally to skip the shutdown case for testing reasons,
but the line `if ((LTC2943_code_to_celcius_temperature(temperature), 4) >= 60)`


does `(LTC2943_code_to_celcius_temperature(temperature), 4)` which would always evaluate to 4,
no matter what the evaluated temperature actually is.

You can test it with this simple CPP program:
```cpp
#include <iostream>

using namespace std;

int main() {
    int temp;
    cout << "enter temp: ";
    cin >> temp;
    if ((temp, 4) >= 5) {
        cout << temp << endl;
    } else {
        cout << "entered else case although entered temp was greater than 5, "
                "because second operand is always chosen."
             << endl;
    }
}
```

If you compile this with `-Wall` it would give you the warning:
```
temp.cpp: In function ‘int main()’:
temp.cpp:9:10: warning: left operand of comma operator has no effect [-Wunused-value]
    9 |     if ((temp, 4) >= 5) {
      |          ^~~~
```

as you see, your left operand would never make a difference, hence that if-statement would never
execute since it evaluates `4 >= 60`.
