### PR TITLE
Update Header.astro

### DIFF
--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -24,7 +24,7 @@ import Container from "@components/Container.astro"
       <nav class="hidden md:flex items-center justify-center text-sm gap-1">
         {
           LINKS.map((LINK) => (
-            <a href={LINK.HREF} target="_blank" class={cn("h-8 rounded-full px-3 text-current", "flex items-center justify-center", "transition-colors duration-300 ease-in-out", pathname === LINK.HREF || "/" + subpath?.[0] === LINK.HREF ? "bg-black dark:bg-white text-white dark:text-black" : "hover:bg-black/5 dark:hover:bg-white/20 hover:text-black dark:hover:text-white")}>
+            <a href={LINK.HREF} class={cn("h-8 rounded-full px-3 text-current", "flex items-center justify-center", "transition-colors duration-300 ease-in-out", pathname === LINK.HREF || "/" + subpath?.[0] === LINK.HREF ? "bg-black dark:bg-white text-white dark:text-black" : "hover:bg-black/5 dark:hover:bg-white/20 hover:text-black dark:hover:text-white")}>
               {LINK.TEXT}
             </a>
           ))


### PR DESCRIPTION
This pull request includes a small change to the `website/src/components/Header.astro` file. The change removes the `target="_blank"` attribute from the anchor tags within the navigation component.

* [`website/src/components/Header.astro`](diffhunk://#diff-c43a1ede78dc6eab935173a5f2648ccfe32f59abd7f90bcc440dce860a082176L27-R27): Removed `target="_blank"` attribute from anchor tags to prevent opening links in new tabs.